### PR TITLE
Do not map <Enter> everywhere

### DIFF
--- a/plugin/testkey.vim
+++ b/plugin/testkey.vim
@@ -44,11 +44,28 @@ function! g:TestKey.lookup(file, line)
   return g:TestKey.command
 endfunction
 
-
 function! TestKey()
   w
   exec g:TestKey.lookup(expand("%"), line("."))
 endfunction
 
-execute "map " . g:TestKey.testkey . " :call TestKey()<cr>"
+function! s:map_testkey()
+  " The `<Enter>` key is a bit problematic in certain buffers where the
+  " `<Enter>` key have a specific meaning and is not replaceable. This buffers
+  " are:
+  " - [Command Line], (:h cmdwin) which is a regular vim buffer with a buffer name
+  "   enclosed in square brackets
+  " - Quickfix and Location List
+  " - Any buffer who already have mapped the `<Enter>` key
+  if g:TestKey.testkey != '<Enter>' ||
+        \ ( bufname('')[0] != '[' &&
+        \   &filetype !=# 'qf' &&
+        \   empty(maparg(g:TestKey.testkey)) )
+    execute 'map <buffer>' g:TestKey.testkey ':call TestKey()<cr>'
+  endif
+endfunction
 
+augroup testkey
+  autocmd!
+  autocmd FileType * call s:map_testkey()
+augroup END


### PR DESCRIPTION
First, thanks for the plugin, I wanted to do something similar myself so you spare me to write it :P I use the `<Enter>` key myself for launching the tests but inside vim it has some inconvenience: for example if you use the [cmdwin](http://vimdoc.sourceforge.net/htmldoc/cmdline.html#cmdline-window) the `<Enter>` key there is used for other purposes, the same thing is true for the Quickfix List and the Location List, plus other plugins like Tagbar, NERDTree, netwr etc etc. So I tried with something like this and it seems to work. I couldn't test this thing though because [vim-spec](https://github.com/kana/vim-vspec/) launch the tests with vim in Ex-mode so no windows operations can be used.
